### PR TITLE
Mark new error directory as internal

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,7 +9,7 @@ server {
 	server_name rb.ozzt.pw;
 
 	set_real_ip_from 10.8.0.3;
-
+	
 	real_ip_header X-Forwarded-For;
 	
 	# 4XX Series Errors
@@ -46,7 +46,7 @@ server {
 		rewrite ^(.*)$ $1.php last;
 	}
 	
-	location /errors/ {
+	location /error/ {
 		internal;
 	}
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,7 +9,7 @@ server {
 	server_name rb.ozzt.pw;
 
 	set_real_ip_from 10.8.0.3;
-	
+
 	real_ip_header X-Forwarded-For;
 	
 	# 4XX Series Errors


### PR DESCRIPTION
In commit 1d91507, the error directory was changed from /errors/ to /error/.